### PR TITLE
fix: do not restrict version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0"
+      version = ">= 5"
     }
   }
 }


### PR DESCRIPTION
I unarchived this repository as I need to remove AWS provider restriction as this module is still in use by our platform-aws-transfer repo.